### PR TITLE
Replace icons with fontawesome

### DIFF
--- a/assets/scss/biz-portal.scss
+++ b/assets/scss/biz-portal.scss
@@ -22,6 +22,10 @@ body {
   overflow: auto;
   position: relative;
 }
+.fa-list-icon {
+  margin-right: 4px;
+  text-align: center;
+}
 
 .navbar {
   @include mdc-top-app-bar-fill-color(#fff);
@@ -89,6 +93,10 @@ body {
 
 .text-field-business.mdc-text-field--focused {
   @include mdc-text-field-label-color(rgba(0, 0, 0, 0.8));
+}
+
+.info-icon {
+    color: #737373;
 }
 
 #custom-templates {

--- a/assets/scss/biz-portal.scss
+++ b/assets/scss/biz-portal.scss
@@ -262,8 +262,9 @@ body {
         display: flex;
         align-items: center;
 
-        .material-icons {
-          margin-right: 8px;
+        .fa-list-icon {
+          margin-right: 9px;
+          text-align: center;
         }
       }
     }
@@ -298,8 +299,9 @@ body {
         display: flex;
         align-items: center;
 
-        .material-icons {
-          margin-right: 8px;
+        .fa-list-icon {
+          margin-right: 9px;
+          text-align: center;
         }
       }
     }

--- a/biz_portal/apps/portal/templates/portal/business_detail.html
+++ b/biz_portal/apps/portal/templates/portal/business_detail.html
@@ -67,7 +67,7 @@
       <details class="mdc-expansion mdc-theme--background mdc-elevation--z2">
         <summary class="mdc-expansion__summary">
           <span class="business-profile-location mdc-list-item">
-            <i class="fas fa-location-arrow mdc-theme--primary" aria-hidden="true"></i>
+            <i class="fas fa-location-arrow fa-list-icon mdc-theme--primary mdc-list-item__graphic" aria-hidden="true"></i>
             <span class="mdc-expansion__header">{{ object.region }}</span>
           </span>
           <i class="fas fa-arrow-down arrow-down" aria-hidden="true"></i>
@@ -86,19 +86,19 @@
             <span class="mdc-expansion__header">{{ object.registration_status.label }}</span>
           </span>
           <div data-tooltip="Indicates the current registration status of the business. A business's status can range from being In business or Deregistered to Closed.">
-            <i class="fas fa-info-circle mdc-list-item__graphic" aria-hidden="true"></i>
+            <i class="fas fa-info-circle info-icon" aria-hidden="true"></i>
           </div>
         </summary>
       </details>
       <details class="mdc-theme--background mdc-elevation--z2">
         <summary class="mdc-expansion__summary">
           <span class="business-profile-location mdc-list-item">
-            <i class="fas fa-suitcase mdc-list-item__graphic" aria-hidden="true"></i>
+            <i class="fas fa-suitcase fa-list-icon mdc-theme--primary mdc-list-item__graphic" aria-hidden="true"></i>
             <span class="type-header">Type:</span>
             <span class="mdc-expansion__header">{{ object.registered_business_type.label }}</span>
           </span>
           <div data-tooltip="Describes the type of business registered, such as private company and non-profit company for example.">
-            <i class="fas fa-info-circle mdc-list-item__graphic" aria-hidden="true"></i>
+            <i class="fas fa-info-circle info-icon" aria-hidden="true"></i>
           </div>
         </summary>
       </details>
@@ -112,7 +112,7 @@
             <span class="mdc-expansion__header">{{ object.registration_number }}</span>
           </span>
           <div data-tooltip="Indicates the registration number of the business.">
-            <i class="fas fa-info-circle mdc-list-item__graphic" aria-hidden="true"></i>
+            <i class="fas fa-info-circle info-icon" aria-hidden="true"></i>
           </div>
         </summary>
       </details>

--- a/biz_portal/apps/portal/templates/portal/business_detail.html
+++ b/biz_portal/apps/portal/templates/portal/business_detail.html
@@ -67,7 +67,7 @@
       <details class="mdc-expansion mdc-theme--background mdc-elevation--z2">
         <summary class="mdc-expansion__summary">
           <span class="business-profile-location mdc-list-item">
-            <i class="fas fa-location-arrow fa-list-icon mdc-theme--primary mdc-list-item__graphic" aria-hidden="true"></i>
+            <i class="fas fa-map-marker fa-list-icon mdc-theme--primary mdc-list-item__graphic" aria-hidden="true"></i>
             <span class="mdc-expansion__header">{{ object.region }}</span>
           </span>
           <i class="fas fa-chevron-down arrow-down" aria-hidden="true"></i>

--- a/biz_portal/apps/portal/templates/portal/business_detail.html
+++ b/biz_portal/apps/portal/templates/portal/business_detail.html
@@ -67,7 +67,7 @@
       <details class="mdc-expansion mdc-theme--background mdc-elevation--z2">
         <summary class="mdc-expansion__summary">
           <span class="business-profile-location mdc-list-item">
-            <i class="fas fa-map-marker fa-list-icon mdc-theme--primary mdc-list-item__graphic" aria-hidden="true"></i>
+            <i class="fas fa-map-marker-alt fa-list-icon mdc-theme--primary mdc-list-item__graphic" aria-hidden="true"></i>
             <span class="mdc-expansion__header">{{ object.region }}</span>
           </span>
           <i class="fas fa-chevron-down arrow-down" aria-hidden="true"></i>

--- a/biz_portal/apps/portal/templates/portal/business_detail.html
+++ b/biz_portal/apps/portal/templates/portal/business_detail.html
@@ -70,7 +70,7 @@
             <i class="fas fa-location-arrow fa-list-icon mdc-theme--primary mdc-list-item__graphic" aria-hidden="true"></i>
             <span class="mdc-expansion__header">{{ object.region }}</span>
           </span>
-          <i class="fas fa-arrow-down arrow-down" aria-hidden="true"></i>
+          <i class="fas fa-chevron-down arrow-down" aria-hidden="true"></i>
         </summary>
         <div class="mdc-expansion__content">
           <span class="mdc-expansion__header address-detail">{% firstof object.supplied_physical_address object.registered_physical_address %}</span>

--- a/biz_portal/apps/portal/templates/portal/business_detail.html
+++ b/biz_portal/apps/portal/templates/portal/business_detail.html
@@ -7,7 +7,7 @@
     <div>
       <div class="business-menu">
         <button class="mdc-button business-menu-button" id="show-business-menu">
-          <i class="material-icons mdc-button__icon" aria-hidden="true">more_horiz</i>
+          <i class="fas fa-ellipsis-h mdc-button__icon" aria-hidden="true"></i>
         </button>
       </div>
       <div class="mdc-dialog"
@@ -67,10 +67,10 @@
       <details class="mdc-expansion mdc-theme--background mdc-elevation--z2">
         <summary class="mdc-expansion__summary">
           <span class="business-profile-location mdc-list-item">
-            <i class="material-icons mdc-list-item__graphic" aria-hidden="true">location_on</i>
+            <i class="fas fa-location-arrow mdc-theme--primary" aria-hidden="true"></i>
             <span class="mdc-expansion__header">{{ object.region }}</span>
           </span>
-          <i class="material-icons mdc-list-item__graphic arrow-down" aria-hidden="true">keyboard_arrow_down</i>
+          <i class="fas fa-arrow-down arrow-down" aria-hidden="true"></i>
         </summary>
         <div class="mdc-expansion__content">
           <span class="mdc-expansion__header address-detail">{% firstof object.supplied_physical_address object.registered_physical_address %}</span>
@@ -86,19 +86,19 @@
             <span class="mdc-expansion__header">{{ object.registration_status.label }}</span>
           </span>
           <div data-tooltip="Indicates the current registration status of the business. A business's status can range from being In business or Deregistered to Closed.">
-            <i class="material-icons mdc-list-item__graphic" aria-hidden="true">info</i>
+            <i class="fas fa-info-circle mdc-list-item__graphic" aria-hidden="true"></i>
           </div>
         </summary>
       </details>
       <details class="mdc-theme--background mdc-elevation--z2">
         <summary class="mdc-expansion__summary">
           <span class="business-profile-location mdc-list-item">
-            <i class="material-icons mdc-list-item__graphic" aria-hidden="true">work</i>
+            <i class="fas fa-suitcase mdc-list-item__graphic" aria-hidden="true"></i>
             <span class="type-header">Type:</span>
             <span class="mdc-expansion__header">{{ object.registered_business_type.label }}</span>
           </span>
           <div data-tooltip="Describes the type of business registered, such as private company and non-profit company for example.">
-            <i class="material-icons mdc-list-item__graphic" aria-hidden="true">info</i>
+            <i class="fas fa-info-circle mdc-list-item__graphic" aria-hidden="true"></i>
           </div>
         </summary>
       </details>
@@ -112,7 +112,7 @@
             <span class="mdc-expansion__header">{{ object.registration_number }}</span>
           </span>
           <div data-tooltip="Indicates the registration number of the business.">
-            <i class="material-icons mdc-list-item__graphic" aria-hidden="true">info</i>
+            <i class="fas fa-info-circle mdc-list-item__graphic" aria-hidden="true"></i>
           </div>
         </summary>
       </details>

--- a/biz_portal/apps/portal/templates/portal/business_list.html
+++ b/biz_portal/apps/portal/templates/portal/business_list.html
@@ -34,7 +34,7 @@
           <div class="business-details-location">
               <summary class="business-summary">
                 <span class="business-details-content">
-                  <i class="fas fa-location-arrow fa-list-icon mdc-list-item__graphic mdc-theme--primary" aria-hidden="true"></i>
+                  <i class="fas fa-map-marker fa-list-icon mdc-list-item__graphic mdc-theme--primary" aria-hidden="true"></i>
                   <span class="header-summary">{{ business.region.label }}</span>
                 </span>
               </summary>

--- a/biz_portal/apps/portal/templates/portal/business_list.html
+++ b/biz_portal/apps/portal/templates/portal/business_list.html
@@ -34,7 +34,7 @@
           <div class="business-details-location">
               <summary class="business-summary">
                 <span class="business-details-content">
-                  <i class="fas fa-location-arrow mdc-theme--primary" aria-hidden="true"></i>
+                  <i class="fas fa-location-arrow fa-list-icon mdc-list-item__graphic mdc-theme--primary" aria-hidden="true"></i>
                   <span class="header-summary">{{ business.region.label }}</span>
                 </span>
               </summary>

--- a/biz_portal/apps/portal/templates/portal/business_list.html
+++ b/biz_portal/apps/portal/templates/portal/business_list.html
@@ -34,7 +34,7 @@
           <div class="business-details-location">
               <summary class="business-summary">
                 <span class="business-details-content">
-                  <i class="fas fa-map-marker fa-list-icon mdc-list-item__graphic mdc-theme--primary" aria-hidden="true"></i>
+                  <i class="fas fa-map-marker-alt fa-list-icon mdc-list-item__graphic mdc-theme--primary" aria-hidden="true"></i>
                   <span class="header-summary">{{ business.region.label }}</span>
                 </span>
               </summary>

--- a/biz_portal/apps/portal/templates/portal/business_list.html
+++ b/biz_portal/apps/portal/templates/portal/business_list.html
@@ -21,7 +21,7 @@
         <div class="business-category">
           <span class="business-category-text">{{ business.sector.label }}</span>
           <span>
-            <i class="material-icons mdc-list-item__graphic mdc-theme--primary" aria-hidden="true">home</i>
+            <i class="fas fa-home mdc-theme--primary" aria-hidden="true"></i>
           </span>
         </div>
         <div class="business-name mdc-theme--primary">
@@ -34,7 +34,7 @@
           <div class="business-details-location">
               <summary class="business-summary">
                 <span class="business-details-content">
-                  <i class="material-icons mdc-list-item__graphic mdc-theme--primary" aria-hidden="true">location_on</i>
+                  <i class="fas fa-location-arrow mdc-theme--primary" aria-hidden="true"></i>
                   <span class="header-summary">{{ business.region.label }}</span>
                 </span>
               </summary>

--- a/biz_portal/apps/portal/templates/portal/home.html
+++ b/biz_portal/apps/portal/templates/portal/home.html
@@ -31,7 +31,7 @@
                     <p class="top-sector-count">{{ sector.count }} Businesses</p>
                   </div>
                 </span>
-                <i class="material-icons mdc-list-item__graphic arrow-right" aria-hidden="true">keyboard_arrow_right</i>
+                <i class="fas fa-arrow-right mdc-list-item__graphic arrow-right" aria-hidden="true"></i>
               </summary>
             </li>
           </div>

--- a/biz_portal/apps/portal/templates/portal/search_filter_region_snippet.html
+++ b/biz_portal/apps/portal/templates/portal/search_filter_region_snippet.html
@@ -4,7 +4,7 @@
 <div class="search-result">
   <summary class="close_summary">
     <div class="icon-and-filter-option">
-      <i class="fas fa-location-arrow fa-list-icon mdc-theme--primary" aria-hidden="true"></i>
+      <i class="fas fa-map-marker fa-list-icon mdc-theme--primary" aria-hidden="true"></i>
       <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">
         {{ request.GET.region }}
       </h3>
@@ -20,7 +20,7 @@
 <details class="mdc-expansion">
   <summary class="mdc-expansion__summary">
     <div class="icon-and-filter-option">
-      <i class="fas fa-location-arrow fa-list-icon mdc-theme--primary" aria-hidden="true"></i>
+      <i class="fas fa-map-marker fa-list-icon mdc-theme--primary" aria-hidden="true"></i>
       <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">
         Location
       </h3>

--- a/biz_portal/apps/portal/templates/portal/search_filter_region_snippet.html
+++ b/biz_portal/apps/portal/templates/portal/search_filter_region_snippet.html
@@ -26,7 +26,7 @@
       </h3>
     </div>
     <div class="business-directory-count-arrow">
-      <i class="fas fa-arrow-down arrow-down" aria-hidden="true"></i>
+      <i class="fas fa-chevron-down arrow-down" aria-hidden="true"></i>
     </div>
   </summary>
   {% for region in region_business_counts %}

--- a/biz_portal/apps/portal/templates/portal/search_filter_region_snippet.html
+++ b/biz_portal/apps/portal/templates/portal/search_filter_region_snippet.html
@@ -4,7 +4,7 @@
 <div class="search-result">
   <summary class="close_summary">
     <div class="icon-and-filter-option">
-      <i class="fas fa-location-arrow mdc-theme--primary" aria-hidden="true"></i>
+      <i class="fas fa-location-arrow fa-list-icon mdc-theme--primary" aria-hidden="true"></i>
       <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">
         {{ request.GET.region }}
       </h3>
@@ -20,7 +20,7 @@
 <details class="mdc-expansion">
   <summary class="mdc-expansion__summary">
     <div class="icon-and-filter-option">
-      <i class="fas fa-location-arrow mdc-theme--primary" aria-hidden="true"></i>
+      <i class="fas fa-location-arrow fa-list-icon mdc-theme--primary" aria-hidden="true"></i>
       <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">
         Location
       </h3>

--- a/biz_portal/apps/portal/templates/portal/search_filter_region_snippet.html
+++ b/biz_portal/apps/portal/templates/portal/search_filter_region_snippet.html
@@ -4,14 +4,14 @@
 <div class="search-result">
   <summary class="close_summary">
     <div class="icon-and-filter-option">
-      <i class="material-icons mdc-list-item__graphic mdc-theme--primary" aria-hidden="true">location_on</i>
+      <i class="fas fa-location-arrow mdc-theme--primary" aria-hidden="true"></i>
       <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">
         {{ request.GET.region }}
       </h3>
     </div>
     <div class="business-directory-count-arrow">
       <a href="{% url "business_list" %}?{% param_replace page="" region="" %}">
-        <i class="material-icons mdc-list-item__graphic close" aria-hidden="true">close</i>
+        <i class="fas fa-times close" aria-hidden="true"></i>
       </a>
     </div>
   </summary>
@@ -20,13 +20,13 @@
 <details class="mdc-expansion">
   <summary class="mdc-expansion__summary">
     <div class="icon-and-filter-option">
-      <i class="material-icons mdc-list-item__graphic mdc-theme--primary" aria-hidden="true">location_on</i>
+      <i class="fas fa-location-arrow mdc-theme--primary" aria-hidden="true"></i>
       <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">
         Location
       </h3>
     </div>
     <div class="business-directory-count-arrow">
-      <i class="material-icons mdc-list-item__graphic arrow-down" aria-hidden="true">keyboard_arrow_down</i>
+      <i class="fas fa-arrow-down arrow-down" aria-hidden="true"></i>
     </div>
   </summary>
   {% for region in region_business_counts %}
@@ -34,7 +34,7 @@
     <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">{{ region.label }}</h3>
     <div class="business-directory-count-arrow">
       <div class="location-count">{{ region.count }}</div>
-      <i class="material-icons mdc-list-item__graphic arrow-right" aria-hidden="true">keyboard_arrow_right</i>
+      <i class="fas fa-arrow-right arrow-right" aria-hidden="true"></i>
     </div>
   </a>
   {% endfor %}

--- a/biz_portal/apps/portal/templates/portal/search_filter_region_snippet.html
+++ b/biz_portal/apps/portal/templates/portal/search_filter_region_snippet.html
@@ -4,7 +4,7 @@
 <div class="search-result">
   <summary class="close_summary">
     <div class="icon-and-filter-option">
-      <i class="fas fa-map-marker fa-list-icon mdc-theme--primary" aria-hidden="true"></i>
+      <i class="fas fa-map-marker-alt fa-list-icon mdc-theme--primary" aria-hidden="true"></i>
       <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">
         {{ request.GET.region }}
       </h3>
@@ -20,7 +20,7 @@
 <details class="mdc-expansion">
   <summary class="mdc-expansion__summary">
     <div class="icon-and-filter-option">
-      <i class="fas fa-map-marker fa-list-icon mdc-theme--primary" aria-hidden="true"></i>
+      <i class="fas fa-map-marker-alt fa-list-icon mdc-theme--primary" aria-hidden="true"></i>
       <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">
         Location
       </h3>

--- a/biz_portal/apps/portal/templates/portal/search_filter_sector_snippet.html
+++ b/biz_portal/apps/portal/templates/portal/search_filter_sector_snippet.html
@@ -4,7 +4,7 @@
 <div class="search-result">
   <summary class="close_summary">
     <div class="icon-and-filter-option">
-      <i class="fas fa-wrench mdc-theme--primary" aria-hidden="true"></i>
+      <i class="fas fa-wrench fa-list-icon mdc-theme--primary" aria-hidden="true"></i>
       <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">
         {{ request.GET.sector }}
       </h3>
@@ -20,7 +20,7 @@
 <details class="mdc-expansion">
   <summary class="mdc-expansion__summary">
     <div class="icon-and-filter-option">
-      <i class="fas fa-wrench mdc-theme--primary" aria-hidden="true"></i>
+      <i class="fas fa-wrench fa-list-icon mdc-theme--primary" aria-hidden="true"></i>
       <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">
         Sector
       </h3>

--- a/biz_portal/apps/portal/templates/portal/search_filter_sector_snippet.html
+++ b/biz_portal/apps/portal/templates/portal/search_filter_sector_snippet.html
@@ -4,14 +4,14 @@
 <div class="search-result">
   <summary class="close_summary">
     <div class="icon-and-filter-option">
-      <i class="material-icons mdc-list-item__graphic mdc-theme--primary" aria-hidden="true">location_on</i>
+      <i class="fas fa-wrench mdc-theme--primary" aria-hidden="true"></i>
       <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">
         {{ request.GET.sector }}
       </h3>
     </div>
     <div class="business-directory-count-arrow">
       <a href="{% url "business_list" %}?{% param_replace page="" sector="" %}">
-        <i class="material-icons mdc-list-item__graphic close" aria-hidden="true">close</i>
+        <i class="fas fa-times close" aria-hidden="true"></i>
       </a>
     </div>
   </summary>
@@ -20,13 +20,13 @@
 <details class="mdc-expansion">
   <summary class="mdc-expansion__summary">
     <div class="icon-and-filter-option">
-      <i class="material-icons mdc-list-item__graphic mdc-theme--primary" aria-hidden="true">build</i>
+      <i class="fas fa-wrench mdc-theme--primary" aria-hidden="true"></i>
       <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">
         Sector
       </h3>
     </div>
     <div class="business-directory-count-arrow">
-      <i class="material-icons mdc-list-item__graphic arrow-down" aria-hidden="true">keyboard_arrow_down</i>
+      <i class="fas fa-arrow-down arrow-down" aria-hidden="true"></i>
     </div>
   </summary>
   {% for sector in sector_business_counts %}
@@ -34,7 +34,7 @@
     <h3 class="mdc-typography--subtitle2 subtitle-business-directory-category">{{ sector.label }}</h3>
     <div class="business-directory-count-arrow">
       <div class="location-count">{{ sector.count }}</div>
-      <i class="material-icons mdc-list-item__graphic arrow-right" aria-hidden="true">keyboard_arrow_right</i>
+      <i class="fas fa-arrow-right arrow-right" aria-hidden="true"></i>
     </div>
   </a>
   {% endfor %}

--- a/biz_portal/apps/portal/templates/portal/search_filter_sector_snippet.html
+++ b/biz_portal/apps/portal/templates/portal/search_filter_sector_snippet.html
@@ -26,7 +26,7 @@
       </h3>
     </div>
     <div class="business-directory-count-arrow">
-      <i class="fas fa-arrow-down arrow-down" aria-hidden="true"></i>
+      <i class="fas fa-chevron-down arrow-down" aria-hidden="true"></i>
     </div>
   </summary>
   {% for sector in sector_business_counts %}

--- a/biz_portal/apps/portal/templates/portal/search_filter_snippet.html
+++ b/biz_portal/apps/portal/templates/portal/search_filter_snippet.html
@@ -27,7 +27,7 @@
             data-view-all-url="{% url "business_list" %}?{% param_replace sector=request.GET.sector region=request.GET.region q="" %}"
             >
           <div class="search-icon-container">
-            <i class="material-icons mdc-text-field__icon search-icon" tabindex="0" role="button">search</i>
+            <i class="search-icon fas fa-search" tabindex="0" role="button"></i>
           </div>
         </div><!-- end .search-query-input-container -->
       </div><!-- end .layout -->

--- a/biz_portal/templates/base.html
+++ b/biz_portal/templates/base.html
@@ -15,6 +15,7 @@
     <![endif]-->
 
     <link rel="icon" href="{% static 'images/favicons/favicon.ico' %}">
+    <script src="https://kit.fontawesome.com/7373e11076.js"></script>
 
     {% block css %}
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
@@ -44,20 +45,20 @@
 
           {% if current_site.municipality.add_update_business_url %}
           <a class="mdc-list-item" href="{{  current_site.municipality.add_update_business_url }}">
-            <i class="material-icons mdc-list-item__graphic" aria-hidden="true">store</i>
+            <i class="fas fa-building-o mdc-list-item__graphic" aria-hidden="true">store</i>
             <span class="mdc-list-item__text">Add my business</span>
           </a>
           {% endif %}
 
           {% if request.user.is_staff %}
           <a class="mdc-list-item" href="#">
-            <i class="material-icons mdc-list-item__graphic" aria-hidden="true">arrow_downward</i>
+            <i class="fas fa-arrow-down mdc-list-item__graphic" aria-hidden="true"></i>
             <span class="mdc-list-item__text">Download data</span>
           </a>
           {% endif %}
 
           <a class="mdc-list-item" href="{% url 'municipality_detail' %}">
-            <i class="material-icons mdc-list-item__graphic" aria-hidden="true">call</i>
+            <i class="fas fa-phone mdc-list-item__graphic" aria-hidden="true"></i>
             <span class="mdc-list-item__text">Contact municipality</span>
           </a>
 
@@ -66,9 +67,7 @@
              href="/admin/"
              aria-selected="true"
              >
-            <i class="material-icons mdc-list-item__graphic" aria-hidden="true">
-              edit
-            </i>
+            <i class="fas fa-edit mdc-list-item__graphic" aria-hidden="true"></i>
             <span class="mdc-list-item__text">Manage businesses</span>
           </a>
           {% endif %}
@@ -78,9 +77,7 @@
              href="/admin/logout"
              aria-selected="true"
              >
-            <i class="material-icons mdc-list-item__graphic" aria-hidden="true">
-              exit_to_app
-            </i>
+            <i class="fas fa-sign-out-alt mdc-list-item__graphic" aria-hidden="true"></i>
             <span class="mdc-list-item__text">Logout</span>
           </a>
           {% else %}
@@ -88,8 +85,8 @@
              href="/admin/"
              aria-selected="true"
              >
-            <i class="material-icons mdc-list-item__graphic" aria-hidden="true">
-              exit_to_app
+            <i class="fas fa-sign-in-alt mdc-list-item__graphic" aria-hidden="true">
+
             </i>
             <span class="mdc-list-item__text">Admin Login</span>
           </a>
@@ -105,7 +102,7 @@
           </span>
         </section>
         <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end">
-          <button class="demo-menu material-icons mdc-top-app-bar__navigation-icon">menu</button>
+          <button class="demo-menu mdc-top-app-bar__navigation-icon"><i class="fas fa-bars"></i></button>
         </section>
       </div>
     </header>

--- a/biz_portal/templates/base.html
+++ b/biz_portal/templates/base.html
@@ -52,7 +52,7 @@
 
           {% if request.user.is_staff %}
           <a class="mdc-list-item" href="#">
-            <i class="fas fa-arrow-down mdc-list-item__graphic" aria-hidden="true"></i>
+            <i class="fas fa-chevron-down mdc-list-item__graphic" aria-hidden="true"></i>
             <span class="mdc-list-item__text">Download data</span>
           </a>
           {% endif %}


### PR DESCRIPTION
Trello: https://trello.com/c/M09cSw1O

- Replaces all material design icons on the site with font-awesome icons
- Adds two new CSS classes to assist with the styling of font awesome icons

Note: all icons are now showing on our little phone, but it's not rendering in the correct positions. It wraps over to the next row most of the time, but I can't reproduce it on my dev machine and I can't debug it on the little phone, so perhaps it's sufficient to leave as is? Everything is visible and accessible.