### PR TITLE
Fix-different-muni-edit-access

### DIFF
--- a/biz_portal/apps/portal/admin.py
+++ b/biz_portal/apps/portal/admin.py
@@ -10,6 +10,10 @@ from biz_portal.apps.portal.rules import is_business_muni_admin
 from . import models
 
 
+class BusinessMembershipInlineAdmin(rules_admin.ObjectPermissionsTabularInline):
+    model = models.BusinessMembership
+
+
 class BusinessMembershipResource(resources.ModelResource):
     def __init__(self, request=None):
         super(BusinessMembershipResource, self).__init__()
@@ -39,63 +43,6 @@ class BusinessMembershipResource(resources.ModelResource):
             "surname",
             "membership_type",
         )
-
-
-class BusinessMembershipInlineAdmin(rules_admin.ObjectPermissionsTabularInline):
-    model = models.BusinessMembership
-
-    def has_import_permission(self, request, obj=None):
-        if (
-            request.user.is_superuser
-            or request.user.groups.filter(name="Integration Admins").exists()
-        ):
-            return True
-
-        business = None
-        if obj:
-            business = models.Business.objects.get(pk=obj.pk)
-        return is_business_muni_admin(request.user, business)
-
-    def has_change_permission(self, request, obj=None):
-        if (
-            request.user.is_superuser
-            or request.user.groups.filter(name="Integration Admins").exists()
-        ):
-            return True
-
-        business = None
-        if obj:
-            business = models.Business.objects.get(pk=obj.pk)
-        return is_business_muni_admin(request.user, business)
-
-    def has_delete_permission(self, request, obj=None):
-        if (
-            request.user.is_superuser
-            or request.user.groups.filter(name="Integration Admins").exists()
-        ):
-            return True
-
-        business = None
-        if obj:
-            business = models.Business.objects.get(pk=obj.pk)
-        return is_business_muni_admin(request.user, business)
-
-
-class BusinessMembershipAdmin(ImportMixin):
-    model = models.BusinessMembership
-    resource_class = BusinessMembershipResource
-    fields = ("business", "id_number", "first_names", "surname", "membership_type")
-    list_display = (
-        "id_number",
-        "first_names",
-        "surname",
-        "membership_type",
-        "business",
-    )
-    list_display_links = ("id_number",)
-
-    def has_import_permission(self, request):
-        return request.user.is_superuser
 
 
 class BusinessResource(resources.ModelResource):

--- a/biz_portal/apps/portal/admin.py
+++ b/biz_portal/apps/portal/admin.py
@@ -5,41 +5,7 @@ from import_export.admin import ImportExportMixin, ImportMixin
 from import_export.formats.base_formats import XLSX
 from rules.contrib import admin as rules_admin
 
-from biz_portal.apps.portal.models import get_member_id
-from biz_portal.apps.portal.rules import is_business_muni_admin
-
 from . import models
-
-
-class BusinessMembershipResource(resources.ModelResource):
-    def __init__(self, request=None):
-        super(BusinessMembershipResource, self).__init__()
-        self.request = request
-
-    business = fields.Field(
-        column_name="business",
-        attribute="business",
-        widget=widgets.ForeignKeyWidget(models.Business, "registration_number"),
-    )
-
-    def before_import_row(self, row, **kwargs):
-        name = row.get("membership_type")
-        id_ = get_member_id(name)
-        row["membership_type"] = id_
-
-    class Meta:
-        model = models.BusinessMembership
-        import_id_fields = ("id_number",)
-        skip_unchanged = True
-        report_skipped = False
-        fields = ("business", "id_number", "first_names", "surname", "membership_type")
-        export_order = (
-            "business",
-            "id_number",
-            "first_names",
-            "surname",
-            "membership_type",
-        )
 
 
 class BusinessMembershipInlineAdmin(rules_admin.ObjectPermissionsTabularInline):

--- a/biz_portal/apps/portal/admin.py
+++ b/biz_portal/apps/portal/admin.py
@@ -10,10 +10,6 @@ from biz_portal.apps.portal.rules import is_business_muni_admin
 from . import models
 
 
-class BusinessMembershipInlineAdmin(rules_admin.ObjectPermissionsTabularInline):
-    model = models.BusinessMembership
-
-
 class BusinessMembershipResource(resources.ModelResource):
     def __init__(self, request=None):
         super(BusinessMembershipResource, self).__init__()
@@ -43,6 +39,10 @@ class BusinessMembershipResource(resources.ModelResource):
             "surname",
             "membership_type",
         )
+
+
+class BusinessMembershipInlineAdmin(rules_admin.ObjectPermissionsTabularInline):
+    model = models.BusinessMembership
 
 
 class BusinessResource(resources.ModelResource):

--- a/biz_portal/apps/portal/admin.py
+++ b/biz_portal/apps/portal/admin.py
@@ -54,8 +54,9 @@ class BusinessMembershipInlineAdmin(rules_admin.ObjectPermissionsTabularInline):
                 if field.rel and field.rel.to != self.parent_model:
                     opts = field.rel.to._meta
                     break
-        codename = get_permission_codename('add', opts)
-        return request.user.has_perm('%s.%s' % (opts.app_label, codename), obj)
+        codename = get_permission_codename("add", opts)
+        return request.user.has_perm("%s.%s" % (opts.app_label, codename), obj)
+
 
 class BusinessResource(resources.ModelResource):
     registration_status = fields.Field(

--- a/biz_portal/apps/portal/importexport.py
+++ b/biz_portal/apps/portal/importexport.py
@@ -1,0 +1,34 @@
+from import_export import fields, resources, widgets
+
+from . import models
+
+
+class BusinessMembershipResource(resources.ModelResource):
+    def __init__(self, request=None):
+        super(BusinessMembershipResource, self).__init__()
+        self.request = request
+
+    business = fields.Field(
+        column_name="business",
+        attribute="business",
+        widget=widgets.ForeignKeyWidget(models.Business, "registration_number"),
+    )
+
+    def before_import_row(self, row, **kwargs):
+        name = row.get("membership_type")
+        id_ = models.get_member_id(name)
+        row["membership_type"] = id_
+
+    class Meta:
+        model = models.BusinessMembership
+        import_id_fields = ("id_number",)
+        skip_unchanged = True
+        report_skipped = False
+        fields = ("business", "id_number", "first_names", "surname", "membership_type")
+        export_order = (
+            "business",
+            "id_number",
+            "first_names",
+            "surname",
+            "membership_type",
+        )

--- a/biz_portal/apps/portal/management/commands/load_business_members.py
+++ b/biz_portal/apps/portal/management/commands/load_business_members.py
@@ -3,7 +3,7 @@ from django.utils.encoding import force_text
 from import_export.formats import base_formats
 from tablib import Dataset
 
-from biz_portal.apps.portal.admin import BusinessMembershipResource
+from biz_portal.apps.portal.importexport import BusinessMembershipResource
 
 
 class Command(BaseCommand):

--- a/biz_portal/apps/portal/rules.py
+++ b/biz_portal/apps/portal/rules.py
@@ -15,13 +15,16 @@ def is_business_muni_admin(user, business):
         return False
 
     if business is None:
-        return True
+        return False
 
     return user.municipality_set.filter(pk=business.region.municipality.pk).exists()
 
 
 @rules.predicate
 def is_muni_admin(user):
+    """
+    Is an admin of SOME municipality
+    """
     logger.debug(f"Predicate {is_muni_admin.__name__}")
     return user.is_staff and user.municipality_set.exists()
 
@@ -32,14 +35,16 @@ is_business_muni_or_integration_admin = is_integration_admin | is_business_muni_
 
 rules.add_perm("portal", rules.always_allow)
 rules.add_perm("portal.view_business", rules.always_allow)
+# This rule can't restrict addition of business to the munis the user can
+# admin so we rely on that being enforced in the ModelAdmin.
 rules.add_perm("portal.add_business", is_muni_or_integration_admin)
 rules.add_perm("portal.change_business", is_business_muni_or_integration_admin)
-rules.add_perm("portal.delete_business", is_business_muni_admin)
+rules.add_perm("portal.delete_business", is_business_muni_or_integration_admin)
 rules.add_perm("portal.add_businessmembership", is_business_muni_or_integration_admin)
 rules.add_perm(
     "portal.change_businessmembership", is_business_muni_or_integration_admin
 )
-rules.add_perm("portal.view_businessmembership", is_business_muni_or_integration_admin)
+rules.add_perm("portal.view_businessmembership", rules.always_allow)
 rules.add_perm(
     "portal.delete_businessmembership", is_business_muni_or_integration_admin
 )

--- a/biz_portal/apps/portal/tests/test_admin.py
+++ b/biz_portal/apps/portal/tests/test_admin.py
@@ -202,7 +202,7 @@ class AdminModifyBusinessTest(TestCase):
             reverse("admin:portal_business_change", args=[business.pk]),
             HTTP_HOST="biz-portal.openup.org.za",
         )
-        # self.assertContains(view_response, "Save")
+        self.assertContains(view_response, "Save")
         self.assertContains(view_response, "Business memberships")
         self.assertContains(view_response, "BARIS")
 
@@ -251,7 +251,7 @@ class AdminModifyBusinessTest(TestCase):
             reverse("admin:portal_business_change", args=[business.pk]),
             HTTP_HOST="biz-portal.openup.org.za",
         )
-        # self.assertNotContains(view_response, "Save")
+        self.assertNotContains(view_response, "Save")
         self.assertContains(view_response, "Business memberships")
         self.assertContains(view_response, "Test")
 

--- a/biz_portal/apps/portal/tests/test_bulk_load.py
+++ b/biz_portal/apps/portal/tests/test_bulk_load.py
@@ -5,6 +5,7 @@ from biz_portal.apps.portal.importexport import BusinessMembershipResource
 
 from .. import models
 
+
 class AdminBulkLoadDirectorsTestCase(TestCase):
     """Test for Bulk loads"""
 

--- a/biz_portal/apps/portal/tests/test_bulk_load.py
+++ b/biz_portal/apps/portal/tests/test_bulk_load.py
@@ -1,0 +1,39 @@
+import tablib
+from django.test import TestCase
+
+from biz_portal.apps.portal.importexport import BusinessMembershipResource
+
+from .. import models
+
+class AdminBulkLoadDirectorsTestCase(TestCase):
+    """Test for Bulk loads"""
+
+    fixtures = ["test_bulk_upload_directors"]
+
+    def test_bulk_load_directors_correctly_match(self):
+        """It verifies bulk upload functionality including correct matching of business by its registration number"""
+        self.assertTrue(self.client.login(username="admin", password="password"))
+        self.assertEqual(models.BusinessMembership.objects.count(), 0)
+
+        data = tablib.Dataset()
+        data.headers = [
+            "business",
+            "id_number",
+            "membership_type",
+            "first_names",
+            "surname",
+        ]
+        data.append(["1990/002791/07", "760712", "Member", "WILLIAM", "VAN RHEEDE"])
+        data.append(["1990/000289/23", "TEST", "Director", "JACOBUS", "VAN RHEEDE"])
+
+        business_membership = BusinessMembershipResource()
+        business_membership.import_data(data, dry_run=False)
+        self.assertEqual(models.BusinessMembership.objects.count(), 2)
+
+        business = models.Business.objects.get(registration_number="1990/002791/07")
+        director = models.BusinessMembership.objects.get(id_number="760712")
+        self.assertEqual(business.id, director.business.id)
+
+        business_2 = models.Business.objects.get(registration_number="1990/000289/23")
+        director_2 = models.BusinessMembership.objects.get(id_number="TEST")
+        self.assertEqual(business_2.id, director_2.business.id)


### PR DESCRIPTION
- no need to worry about superusers in admin permissions - superusers can always do anything
- right now this works mostly fine
  - [x] admin for different muni can't change memberships
  - [x] admin for different muni can't delete memberships
  - [x] admin for different muni can't view memberships
  - [x] admin for different muni can't create memberships
  - [x] admin for business muni can change memberships
  - [x] admin for business muni can delete memberships
  - [x] admin for business muni can view memberships
  - [x] admin for business muni can create memberships
- integration admin can edit all businesses and memberships